### PR TITLE
Added functionality for passing the filename as an argument in the example applications.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
 name = "curves-test-vis"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "glam",
  "minifb",
  "ogawa-rs",
@@ -246,6 +247,7 @@ checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 name = "print-tree"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ogawa-rs",
 ]
 
@@ -451,6 +453,7 @@ dependencies = [
 name = "schema-parsing"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ogawa-rs",
 ]
 

--- a/apps/curves-test-vis/Cargo.toml
+++ b/apps/curves-test-vis/Cargo.toml
@@ -11,3 +11,4 @@ ogawa-rs = { path = "../.." }
 minifb = "0.19"
 thiserror = "1.0"
 glam = "0.9"
+anyhow = "1.0"

--- a/apps/curves-test-vis/src/main.rs
+++ b/apps/curves-test-vis/src/main.rs
@@ -4,10 +4,10 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 enum Error {
     #[error(transparent)]
-    OgawaError(#[from] OgawaError),
+    Ogawa(#[from] OgawaError),
 
     #[error(transparent)]
-    MinifbError(#[from] minifb::Error),
+    Minifb(#[from] minifb::Error),
 
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -71,16 +71,20 @@ fn load_curves(filepath: &str) -> Result<Vec<Curves>, Error> {
 fn main() -> Result<(), Error> {
     let args = std::env::args().collect::<Vec<String>>();
     if args.len() < 2 {
-        return Err(Error::Other(anyhow::anyhow!("Missing required filename argument.")))
+        return Err(Error::Other(anyhow::anyhow!(
+            "Missing required filename argument."
+        )));
     }
 
     println!("loading archives.");
-    let curves_vec = args[1..].iter().map(|filepath| {
-        Ok(load_curves(filepath)?)
-    }).collect::<Result<Vec<_>, Error>>()?;
-    let curves_vec = curves_vec.iter().flat_map(|curves| {
-        curves.iter()
-    }).collect::<Vec<_>>();
+    let curves_vec = args[1..]
+        .iter()
+        .map(|filepath| Ok(load_curves(filepath)?))
+        .collect::<Result<Vec<_>, Error>>()?;
+    let curves_vec = curves_vec
+        .iter()
+        .flat_map(|curves| curves.iter())
+        .collect::<Vec<_>>();
 
     println!("initializing display");
 

--- a/apps/curves-test-vis/src/main.rs
+++ b/apps/curves-test-vis/src/main.rs
@@ -8,6 +8,9 @@ enum Error {
 
     #[error(transparent)]
     MinifbError(#[from] minifb::Error),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 const WINDOW_WIDTH: usize = 1280;
@@ -66,12 +69,18 @@ fn load_curves(filepath: &str) -> Result<Vec<Curves>, Error> {
 }
 
 fn main() -> Result<(), Error> {
-    println!("loading archives.");
-    let mut curves_vec = vec![];
+    let args = std::env::args().collect::<Vec<String>>();
+    if args.len() < 2 {
+        return Err(Error::Other(anyhow::anyhow!("Missing required filename argument.")))
+    }
 
-    curves_vec.extend(load_curves("test_assets/Eyelashes01.abc")?);
-    curves_vec.extend(load_curves("test_assets/Eyebrows01.abc")?);
-    curves_vec.extend(load_curves("test_assets/Mainhair01.abc")?);
+    println!("loading archives.");
+    let curves_vec = args[1..].iter().map(|filepath| {
+        Ok(load_curves(filepath)?)
+    }).collect::<Result<Vec<_>, Error>>()?;
+    let curves_vec = curves_vec.iter().flat_map(|curves| {
+        curves.iter()
+    }).collect::<Vec<_>>();
 
     println!("initializing display");
 

--- a/apps/print-tree/Cargo.toml
+++ b/apps/print-tree/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 ogawa-rs = { path = "../.." }
+anyhow = "1.0"

--- a/apps/print-tree/src/main.rs
+++ b/apps/print-tree/src/main.rs
@@ -160,7 +160,9 @@ fn print_object_structure(reader: &mut dyn ArchiveReader, archive: &Archive) -> 
 fn main() -> ogawa_rs::Result<()> {
     let args = std::env::args().collect::<Vec<String>>();
     if args.len() < 2 {
-        return Err(ogawa_rs::OgawaError::Other(anyhow::anyhow!("Missing required filename argument.")))
+        return Err(ogawa_rs::OgawaError::Other(anyhow::anyhow!(
+            "Missing required filename argument."
+        )));
     }
 
     let mut reader = MemMappedReader::new(&args[1])?;

--- a/apps/print-tree/src/main.rs
+++ b/apps/print-tree/src/main.rs
@@ -158,10 +158,13 @@ fn print_object_structure(reader: &mut dyn ArchiveReader, archive: &Archive) -> 
 }
 
 fn main() -> ogawa_rs::Result<()> {
-    let filepath = "test_assets/Eyelashes01.abc";
+    let args = std::env::args().collect::<Vec<String>>();
+    if args.len() < 2 {
+        return Err(ogawa_rs::OgawaError::Other(anyhow::anyhow!("Missing required filename argument.")))
+    }
 
-    let mut reader = MemMappedReader::new(filepath)?;
-    // let mut reader = FileReader::new(filepath)?;
+    let mut reader = MemMappedReader::new(&args[1])?;
+    // let mut reader = FileReader::new(&args[1])?;
 
     let archive = Archive::new(&mut reader)?;
 

--- a/apps/schema-parsing/Cargo.toml
+++ b/apps/schema-parsing/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 ogawa-rs = { path = "../.." }
+anyhow = "1.0"

--- a/apps/schema-parsing/src/main.rs
+++ b/apps/schema-parsing/src/main.rs
@@ -1,9 +1,12 @@
 use ogawa_rs::*;
 fn main() -> ogawa_rs::Result<()> {
-    let filepath = "test_assets/Eyelashes01.abc";
+    let args = std::env::args().collect::<Vec<String>>();
+    if args.len() < 2 {
+        return Err(ogawa_rs::OgawaError::Other(anyhow::anyhow!("Missing required filename argument.")))
+    }
 
-    let mut reader = MemMappedReader::new(filepath)?;
-    // let mut reader = FileReader::new(filepath)?;
+    let mut reader = MemMappedReader::new(&args[1])?;
+    // let mut reader = FileReader::new(&args[1])?;
 
     let archive = Archive::new(&mut reader)?;
 

--- a/apps/schema-parsing/src/main.rs
+++ b/apps/schema-parsing/src/main.rs
@@ -2,7 +2,9 @@ use ogawa_rs::*;
 fn main() -> ogawa_rs::Result<()> {
     let args = std::env::args().collect::<Vec<String>>();
     if args.len() < 2 {
-        return Err(ogawa_rs::OgawaError::Other(anyhow::anyhow!("Missing required filename argument.")))
+        return Err(ogawa_rs::OgawaError::Other(anyhow::anyhow!(
+            "Missing required filename argument."
+        )));
     }
 
     let mut reader = MemMappedReader::new(&args[1])?;


### PR DESCRIPTION
The example applications were using filenames of files used internally at Traverse Research. The example applications will now expect filenames based on an argument passed to the application.