### PR TITLE
Return `anyhow::Result` out of apps' `fn main()` and remove recursive error formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,6 @@ homepage = "https://github.com/Traverse-Research/ogawa-rs"
 repository = "https://github.com/Traverse-Research/ogawa-rs"
 keywords = ["ogawa", "alembic"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 include = [
     "src/**",
     "Cargo.toml"

--- a/apps/curves-test-vis/Cargo.toml
+++ b/apps/curves-test-vis/Cargo.toml
@@ -4,11 +4,8 @@ version = "0.1.0"
 authors = ["Max Oomen <max@traverseresearch.nl>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-ogawa-rs = { path = "../.." }
-minifb = "0.23"
-thiserror = "1.0"
-glam = "0.21"
 anyhow = "1.0"
+glam = "0.21"
+minifb = "0.23"
+ogawa-rs = { path = "../.." }

--- a/apps/print-tree/Cargo.toml
+++ b/apps/print-tree/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["Max Oomen <max@traverseresearch.nl>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-ogawa-rs = { path = "../.." }
 anyhow = "1.0"
+ogawa-rs = { path = "../.." }

--- a/apps/print-tree/src/main.rs
+++ b/apps/print-tree/src/main.rs
@@ -157,13 +157,9 @@ fn print_object_structure(reader: &mut dyn ArchiveReader, archive: &Archive) -> 
     Ok(())
 }
 
-fn main() -> ogawa_rs::Result<()> {
+fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect::<Vec<String>>();
-    if args.len() < 2 {
-        return Err(ogawa_rs::OgawaError::Other(anyhow::anyhow!(
-            "Missing required filename argument."
-        )));
-    }
+    anyhow::ensure!(args.len() == 2, "Expecting one filename argument.");
 
     let mut reader = MemMappedReader::new(&args[1])?;
     // let mut reader = FileReader::new(&args[1])?;

--- a/apps/schema-parsing/Cargo.toml
+++ b/apps/schema-parsing/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["Max Oomen <max@traverseresearch.nl>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-ogawa-rs = { path = "../.." }
 anyhow = "1.0"
+ogawa-rs = { path = "../.." }

--- a/apps/schema-parsing/src/main.rs
+++ b/apps/schema-parsing/src/main.rs
@@ -1,11 +1,8 @@
 use ogawa_rs::*;
-fn main() -> ogawa_rs::Result<()> {
+
+fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect::<Vec<String>>();
-    if args.len() < 2 {
-        return Err(ogawa_rs::OgawaError::Other(anyhow::anyhow!(
-            "Missing required filename argument."
-        )));
-    }
+    anyhow::ensure!(args.len() == 2, "Expecting one filename argument.");
 
     let mut reader = MemMappedReader::new(&args[1])?;
     // let mut reader = FileReader::new(&args[1])?;
@@ -66,12 +63,10 @@ fn main() -> ogawa_rs::Result<()> {
                     );
                 }
             },
-            Err(err) => match err {
-                OgawaError::ParsingError(ParsingError::IncompatibleSchema) => {
-                    println!("no compatible schema")
-                }
-                _ => return Err(err),
-            },
+            Err(OgawaError::ParsingError(ParsingError::IncompatibleSchema)) => {
+                println!("no compatible schema")
+            }
+            Err(err) => return Err(err.into()),
         }
 
         let child_count = current.child_count();

--- a/src/result.rs
+++ b/src/result.rs
@@ -52,16 +52,16 @@ impl std::fmt::Display for UserError {
 
 #[derive(Error, Debug)]
 pub enum OgawaError {
-    #[error("Internal error {0}")]
+    #[error("Internal error")]
     InternalError(#[from] InternalError),
 
-    #[error("Parsing error {0}")]
+    #[error("Parsing error")]
     ParsingError(#[from] ParsingError),
 
-    #[error("User error {0}")]
+    #[error("User error")]
     UserError(#[from] UserError),
 
-    #[error("I/O error {0}")]
+    #[error("I/O error")]
     IoError(#[from] std::io::Error),
 
     #[error(transparent)]

--- a/test_assets/.gitignore
+++ b/test_assets/.gitignore
@@ -1,3 +1,0 @@
-Eyebrows01.abc
-Eyelashes01.abc
-Mainhair01.abc


### PR DESCRIPTION
As per our internal testing and usage returning `anyhow::Result` out of `fn main()` results in nice, digestible "caused by" backtrace-like stacks, whereas returning a struct generated by `thiserror` only prints a `Debug` struct.

Furthermore, printing `#[from]` errors via thiserror causes duplication as these are also printed out when `anyhow` recursively walks the `.source()`, and have hence been removed.

---

This change also helps clean up in a followup PR.
