### PR TITLE
Replace `vmap` back with `memmap2` (`memmap` fork/successor)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,14 @@ homepage = "https://github.com/Traverse-Research/ogawa-rs"
 repository = "https://github.com/Traverse-Research/ogawa-rs"
 keywords = ["ogawa", "alembic"]
 
-include = [
-    "src/**",
-    "Cargo.toml"
-]
+include = ["/src"]
 
 [dependencies]
-thiserror = "1.0"
 anyhow = "1.0"
 byteorder = "1.4.3"
 half = "2.1.0"
-vmap = "0.5.1"
+memmap2 = "0.5.8"
+thiserror = "1.0"
 
 [workspace]
 members = [

--- a/apps/curves-test-vis/src/main.rs
+++ b/apps/curves-test-vis/src/main.rs
@@ -12,8 +12,9 @@ fn load_curves(filepath: &str) -> Result<Vec<Curves>> {
 
     let mut result = vec![];
 
-    let mut reader = MemMappedReader::new(filepath)?;
-    // let mut reader = FileReader::new(filepath)?;
+    let file = std::fs::File::open(filepath)?;
+    let mut reader = MemMappedReader::new(file)?;
+    // let mut reader = FileReader::new(file)?;
 
     let archive = Archive::new(&mut reader)?;
 

--- a/apps/print-tree/src/main.rs
+++ b/apps/print-tree/src/main.rs
@@ -161,8 +161,9 @@ fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect::<Vec<String>>();
     anyhow::ensure!(args.len() == 2, "Expecting one filename argument.");
 
-    let mut reader = MemMappedReader::new(&args[1])?;
-    // let mut reader = FileReader::new(&args[1])?;
+    let file = std::fs::File::open(&args[1])?;
+    let mut reader = MemMappedReader::new(file)?;
+    // let mut reader = FileReader::new(file)?;
 
     let archive = Archive::new(&mut reader)?;
 

--- a/apps/schema-parsing/src/main.rs
+++ b/apps/schema-parsing/src/main.rs
@@ -4,8 +4,9 @@ fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect::<Vec<String>>();
     anyhow::ensure!(args.len() == 2, "Expecting one filename argument.");
 
-    let mut reader = MemMappedReader::new(&args[1])?;
-    // let mut reader = FileReader::new(&args[1])?;
+    let file = std::fs::File::open(&args[1])?;
+    let mut reader = MemMappedReader::new(file)?;
+    // let mut reader = FileReader::new(file)?;
 
     let archive = Archive::new(&mut reader)?;
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -65,9 +65,6 @@ pub enum OgawaError {
     IoError(#[from] std::io::Error),
 
     #[error(transparent)]
-    VmapError(#[from] vmap::Error),
-
-    #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
 pub type Result<V, E = OgawaError> = ::std::result::Result<V, E>;


### PR DESCRIPTION
Depends on #15

Back when we decided to replace the unmaintained `memmap` crate, `vmap` seemed to be the only viable alternative; since then the community forked and massively migrated to `memmap2` as evident by having almost [12 million] downloads on crates.io versus [only 10k] on `vmap`.  This crate sees frequent updates and doesn't use the (`vmap` author's homebrew) `system_error` crate which is our last dependency on ancient `cfg-if 0.1` 🎉

Now `MemMappedReader::new()` again takes an `std::fs::File`, just like `FileReader::new()`.

[12 million]: https://crates.io/crates/memmap2
[only 10k]: https://crates.io/crates/vmap
