### PR TITLE
Remove unnecessary `Result` conversions

### DIFF
--- a/src/schemas/polymesh_schema.rs
+++ b/src/schemas/polymesh_schema.rs
@@ -58,7 +58,7 @@ impl PolyMeshSchema {
 
         let uv = properties
             .load_sub_property_by_name("uv", reader, archive)?
-            .map(|x| -> Result<CompoundPropertyReader> { Ok(x.try_into()?) })
+            .map(|x| x.try_into())
             .transpose()?;
 
         let velocities = properties

--- a/src/schemas/xform_schema.rs
+++ b/src/schemas/xform_schema.rs
@@ -107,12 +107,12 @@ impl XformSchema {
 
         let arb_geometry_parameters = properties
             .load_sub_property_by_name(".arbGeomParams", reader, archive)?
-            .map(|x| -> Result<CompoundPropertyReader> { Ok(x.try_into()?) })
+            .map(|x| x.try_into())
             .transpose()?;
 
         let user_properties = properties
             .load_sub_property_by_name(".userProperties", reader, archive)?
-            .map(|x| -> Result<CompoundPropertyReader> { Ok(x.try_into()?) })
+            .map(|x| x.try_into())
             .transpose()?;
 
         Ok(Self {


### PR DESCRIPTION
The `?` on the outer scope takes care of converting from the `try_into()` error, and this also allows Rust to infer the desired `XXXPropertyReader` type, simplifying the closure and getting rid of the `Ok(...?)` pattern.